### PR TITLE
 Allow programming of AVR chips with 256k

### DIFF
--- a/firmware/isp.c
+++ b/firmware/isp.c
@@ -126,7 +126,7 @@ void ispConnect() {
 	}
 	
 	/* Initial extended address value */
-	isp_hiaddr = 0;
+	isp_hiaddr = 0xFF;
 }
 
 void ispDisconnect() {


### PR DESCRIPTION
The usbasp can ben used to program larger chips, like those used in the Mega2560.

The fix is well documented here and in some online forums:
https://petervanhoyweghen.wordpress.com/2015/12/02/the-usbasp-and-atmega2560-mystery/